### PR TITLE
[py3] Fix LDIF parsing

### DIFF
--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -312,7 +312,9 @@ class LDIFParser:
   def _readline(self):
     s = self._input_file.readline()
     if self._file_sends_bytes:
-      s = s.decode('ascii')
+      # The RFC does not allow UTF-8 values, but some implementations do,
+      # including upstream.
+      s = s.decode('utf-8')
     self.line_counter = self.line_counter + 1
     self.byte_counter = self.byte_counter + len(s)
     if not s:
@@ -366,10 +368,12 @@ class LDIFParser:
     value_spec = unfolded_line[colon_pos:colon_pos+2]
     if value_spec==': ':
       attr_value = unfolded_line[colon_pos+2:].lstrip()
-      # All values should be valid ascii.
-      attr_value = attr_value.encode('ascii')
+      # All values should be valid ascii; we support UTF-8 as a
+      # non-official, backwards compatibility layer.
+      attr_value = attr_value.encode('utf-8')
     elif value_spec=='::':
       # attribute value needs base64-decoding
+      # base64 makes sens only for ascii
       attr_value = unfolded_line[colon_pos+2:]
       attr_value = attr_value.encode('ascii')
       attr_value = self._base64_decodestring(attr_value)
@@ -382,7 +386,9 @@ class LDIFParser:
         if u[0] in self._process_url_schemes:
           attr_value = urllib.urlopen(url).read()
     else:
-      attr_value = unfolded_line[colon_pos+1:].encode('ascii')
+      # All values should be valid ascii; we support UTF-8 as a
+      # non-official, backwards compatibility layer.
+      attr_value = unfolded_line[colon_pos+1:].encode('utf-8')
     return attr_type,attr_value
 
   def _consume_empty_lines(self):

--- a/Tests/t_ldif.py
+++ b/Tests/t_ldif.py
@@ -270,6 +270,23 @@ class TestEntryRecords(TestLDIFParser):
             ]
         )
 
+    def test_unencoded_unicode(self):
+        # Encode "Ströder" as UTF-8, without base64
+        # This is an invalid LDIF file, but such files are often found in the wild.
+        self.check_records(
+            """
+            dn: cn=Michael Stroeder,dc=stroeder,dc=com
+            lastname: Ströder
+
+            """,
+            [
+                (
+                    'cn=Michael Stroeder,dc=stroeder,dc=com',
+                    {'lastname': [b'Str\303\266der']},
+                ),
+            ]
+        )
+
     def test_sorted(self):
         self.check_records(
             """

--- a/Tests/t_ldif.py
+++ b/Tests/t_ldif.py
@@ -7,6 +7,8 @@ See http://www.python-ldap.org/ for details.
 $Id: t_ldif.py,v 1.22 2016/07/30 17:15:22 stroeder Exp $
 """
 
+from __future__ import unicode_literals
+
 # from Python's standard lib
 import unittest
 import textwrap
@@ -251,10 +253,13 @@ class TestEntryRecords(TestLDIFParser):
         )
 
     def test_unicode(self):
+        # Encode "Ströder" as UTF-8+Base64
+        # Putting "Ströder" in a single line would be an invalid LDIF file
+        # per https://tools.ietf.org/html/rfc2849 (only safe ascii is allowed in a file)
         self.check_records(
             """
             dn: cn=Michael Stroeder,dc=stroeder,dc=com
-            lastname: Ströder
+            lastname:: U3Ryw7ZkZXI=
 
             """,
             [


### PR DESCRIPTION
Follow the LDIF RFC (https://tools.ietf.org/html/rfc2849):

- A LDIF file MUST contain only safe ASCII
- Any known text value MUST be UTF-8 + base64 encoded
- Any other value (bytes) MUST be base64 encoded

Notes:

- We had to change a test, which was trying to parse an invalid LDIF
  file containing non-ascii text
- The LDIFParser will return:
  * Text for operations, attribute names, distinguisedNames, controls
  * Bytes for all attribute values